### PR TITLE
Add animation frames to collidable box

### DIFF
--- a/Areas/Cherry Trail/Cherry Trail 1.tscn
+++ b/Areas/Cherry Trail/Cherry Trail 1.tscn
@@ -332,7 +332,7 @@ texture_offset = Vector2( 0, 21 )
 height = 32.0
 
 [node name="Box2" parent="YSort/MiddleGround" instance=ExtResource( 30 )]
-position = Vector2( 648, -47 )
+position = Vector2( 646, -119 )
 tile_size = Vector2( 62, 30 )
 grid_size = Vector2( 1, 0.95 )
 texture = ExtResource( 7 )

--- a/Areas/Cherry Trail/Cherry Trail 1.tscn
+++ b/Areas/Cherry Trail/Cherry Trail 1.tscn
@@ -332,12 +332,13 @@ texture_offset = Vector2( 0, 21 )
 height = 32.0
 
 [node name="Box2" parent="YSort/MiddleGround" instance=ExtResource( 30 )]
-position = Vector2( 643, -119 )
+position = Vector2( 648, -47 )
 tile_size = Vector2( 62, 30 )
 grid_size = Vector2( 1, 0.95 )
 texture = ExtResource( 7 )
 texture_offset = Vector2( 0, 21 )
 height = 32.0
+floor_height = -16.0
 
 [node name="BushB" parent="YSort/MiddleGround" instance=ExtResource( 30 )]
 position = Vector2( 119, -243 )

--- a/Scripts/Objects/Collision/CollidableBox.gd
+++ b/Scripts/Objects/Collision/CollidableBox.gd
@@ -20,7 +20,7 @@ var floor_setter_script = preload("res://Scripts/Objects/Collision/FloorSetter.g
 export var tile_size = Vector2(62, 22) setget set_tile_size
 
 # Adjust how many units in the tilemap the box takes up.
-#   - a value of 1,1 means the space of a full 63 x 28 tile is taken.
+#   - a value of 1,1 means the space of tile_size is taken (62 x 22 by default)
 #   - you should set up tile_size so that grid_size is as close to integer values as possible.
 #   - increasing x expands the box diagonally up left (-x axis on tile map).
 #   - increasing y expands the box diagonally up right (-y axis on tile map).
@@ -450,7 +450,7 @@ func _generate_meshes():
 			floor_height
 		) + depth_test_offset)
 		
-		# Generate a mesh containing the remainder of the image on the left side that's not on box
+		# Generate a mesh containing the remainder of the image on the right side that's not on box
 		if is_texture_edge:
 			left = h_coord + tile_step_width
 			right = texture_clip_bounds.size.x

--- a/Scripts/Objects/Collision/CollidableBox.gd
+++ b/Scripts/Objects/Collision/CollidableBox.gd
@@ -8,6 +8,7 @@ extends Node2D
 #---------#
 
 var collision_body_script = preload("res://Scripts/Objects/Collision/CollidableBoxCollisionBody.gd")
+var sprite_mesh_shader = preload("res://Scripts/Rendering/SpriteMesh.gdshader")
 var floor_layer_script = preload("res://Scripts/Objects/Collision/FloorLayer.gd")
 var floor_setter_script = preload("res://Scripts/Objects/Collision/FloorSetter.gd")
 
@@ -47,6 +48,24 @@ export var depth_test_offset = Vector3.ZERO setget set_depth_test_offset
 # Enable/disable preview of the collision box in editor
 export var preview_collision_box = true setget set_preview_collision_box
 
+# If using a spritesheet, the number of frames that span the image horizontally
+export var animation_hframes = 1 setget set_animation_hframes
+
+# If using a spritesheet, the number of frames that span the image vertically
+export var animation_vframes = 1 setget set_animation_vframes
+
+# If using a spritesheet, the current frame of animation
+export var animation_frame = 0 setget set_animation_frame
+
+# Dither alpha values, disabled when use_transparency is true
+export var use_dithering = true
+
+# Offset alpha dithering pattern every frame to create a smoothing effect
+export var use_dither_blending = true
+
+# Allow partial transparency, but greatly reduces depth drawing accuracy
+export var use_transparency: bool = false
+
 #------------#
 # Properties #
 #------------#
@@ -62,11 +81,12 @@ var floor_notify_area = null # notifies player/npc of floor height when collisio
 var floor_notify_area_shape = null # belongs to floor_notify_area
 var half_tile_width = 63.0 / 2.0
 var half_tile_height = 28.0 / 2.0
+var mesh_ysort_containers = [] # texture is split into multiple sprites with texture regions for y-sorting
+var meshes = []
 var is_queued_generate_collider = false
 var is_queued_generate_collision_box_preview = false
-var is_queued_generate_region_sprites = false
+var is_queued_generate_meshes = false
 var is_ready = false # _ready() already called
-var region_sprites = [] # texture is split into multiple sprites with texture regions for y-sorting
 
 #-------------------#
 # Getters / Setters #
@@ -79,55 +99,78 @@ func set_tile_size(new_tile_size):
 	if is_ready:
 		_generate_collider_edges()
 		_queue_generate_collider()
-		_queue_generate_region_sprites()
+		_queue_generate_meshes()
 		_queue_generate_collision_box_preview()
 
 func set_texture(new_texture):
 	texture = new_texture
 	if is_ready:
-		_queue_generate_region_sprites()
+		_queue_generate_meshes()
 
 func set_texture_scale(new_texture_scale):
 	texture_scale = new_texture_scale
 	if is_ready:
-		_queue_generate_region_sprites()
+		_queue_generate_meshes()
 
 func set_texture_offset(new_texture_offset):
 	texture_offset = new_texture_offset
 	if is_ready:
-		_queue_generate_region_sprites()
+		_queue_generate_meshes()
 
 func set_grid_size(new_grid_size):
 	grid_size = new_grid_size
 	if is_ready:
 		_generate_collider_edges()
 		_queue_generate_collider()
-		_queue_generate_region_sprites()
+		_queue_generate_meshes()
 		_queue_generate_collision_box_preview()
 
 func set_height(new_height):
 	height = new_height
 	if is_ready:
-		_queue_generate_region_sprites()
+		_queue_generate_meshes()
 		_queue_generate_collider()
 		_queue_generate_collision_box_preview()
 
 func set_floor_height(new_floor_height):
 	floor_height = new_floor_height
 	if is_ready:
-		_queue_generate_region_sprites()
+		_queue_generate_meshes()
 		_queue_generate_collider()
 		_queue_generate_collision_box_preview()
 
 func set_depth_test_offset(new_depth_test_offset):
 	depth_test_offset = new_depth_test_offset
 	if is_ready:
-		_queue_generate_region_sprites()
+		_queue_generate_meshes()
 
 func set_preview_collision_box(new_preview_collision_box):
 	preview_collision_box = new_preview_collision_box
 	if is_ready:
 		_queue_generate_collision_box_preview()
+
+func set_animation_hframes(new_animation_hframes):
+	animation_hframes = new_animation_hframes
+	if is_ready:
+		_queue_generate_meshes()
+
+func set_animation_vframes(new_animation_vframes):
+	animation_vframes = new_animation_vframes
+	if is_ready:
+		_queue_generate_meshes()
+
+func set_animation_frame(new_animation_frame):
+	animation_frame = new_animation_frame
+	if depth_test_meshes.size() > 0:
+		for mesh in meshes:
+			if mesh != null:
+				mesh.material.set_shader_param("sprite_animation_frame", animation_frame)
+		for mesh_weakref in depth_test_meshes:
+			var mesh = mesh_weakref.get_ref()
+			if mesh:
+				mesh.material_override.set_shader_param("sprite_animation_frame", animation_frame)
+	elif is_ready:
+		_queue_generate_meshes()
 
 #----------------#
 # Node Lifecycle #
@@ -165,14 +208,15 @@ func _initialize_nodes():
 	collision_preview_mesh = null
 	floor_notify_area = null
 	floor_notify_area_shape = null
-	region_sprites = []
+	mesh_ysort_containers = []
+	meshes = []
 	
 	half_tile_width = tile_size.x / 2.0
 	half_tile_height = tile_size.y / 2.0
 
 	_generate_collider_edges()
 	_queue_generate_collider()
-	_queue_generate_region_sprites()
+	_queue_generate_meshes()
 	_queue_generate_collision_box_preview()
 
 func _clear_depth_test_meshes():
@@ -251,25 +295,31 @@ func _generate_collider_edges():
 		),
 	}
 
-func _queue_generate_region_sprites():
-	if not is_queued_generate_region_sprites:
-		is_queued_generate_region_sprites = true
-		call_deferred("_generate_region_sprites")
+func _queue_generate_meshes():
+	if not is_queued_generate_meshes:
+		is_queued_generate_meshes = true
+		call_deferred("_generate_meshes")
 
-func _generate_region_sprites():
-	is_queued_generate_region_sprites = false
+func _generate_meshes():
+	is_queued_generate_meshes = false
 	
 	_clear_depth_test_meshes()
 	
-	if region_sprites.size() > 0:
-		for tx in region_sprites:
+	if mesh_ysort_containers.size() > 0:
+		for tx in mesh_ysort_containers:
 			tx.queue_free()
-		region_sprites = []
+		mesh_ysort_containers = []
+	
+	if meshes.size() > 0:
+		for tx in meshes:
+			tx.queue_free()
+		meshes = []
 	
 	if not texture:
 		return
 	
 	var texture_size = texture.get_size() * texture_scale
+	texture_size = Vector2(texture_size.x / animation_hframes, texture_size.y / animation_vframes)
 	var min_grid_size = min(grid_size.x, grid_size.y)
 	var tile_step_grid_size = min_grid_size / ceil(min_grid_size)
 	var tile_step_width = (tile_step_grid_size * tile_size.x) / 2.0
@@ -488,9 +538,9 @@ func _generate_region_sprites():
 					Vector2(-half_tile_width, -half_tile_height).normalized()
 				)
 				var p0 = left_edge
-				var p1 = Vector2(tile_center.x, top)
-				var p2 = Vector2(left, tile_center.y)
-				var p3 = Vector2(left_edge.x, left_edge.y + (tile_step_height * 2))
+				var p1 = Vector2(left_edge.x, left_edge.y + (tile_step_height * 2))
+				var p2 = Vector2(tile_center.x, top)
+				var p3 = Vector2(left, tile_center.y)
 				vertices = PoolVector2Array()
 				depth_test = PoolRealArray()
 				vertices.push_back(p0)
@@ -571,7 +621,7 @@ func _generate_mesh(
 		global_position.x,
 		Global.calculate_y_sort(Vector3(sort_position.x, sort_position.y, sort_position.z))
 	)
-	region_sprites.push_back(y_sort)
+	mesh_ysort_containers.push_back(y_sort)
 	
 	# Generate UVs
 	var uvs = PoolVector2Array()
@@ -592,20 +642,35 @@ func _generate_mesh(
 	mesh_instance.name = "TexturedMeshInstance2D"
 	mesh_instance.mesh = array_mesh
 	mesh_instance.texture = texture
+	mesh_instance.material = ShaderMaterial.new()
+	mesh_instance.material.shader = sprite_mesh_shader
+	mesh_instance.material.set_shader_param("sprite_animation_hframes", animation_hframes)
+	mesh_instance.material.set_shader_param("sprite_animation_vframes", animation_vframes)
+	mesh_instance.material.set_shader_param("sprite_animation_frame", animation_frame)
 	y_sort.add_child(mesh_instance)
 	mesh_instance.global_position = global_position + Vector2(0.0, -floor_height)
+	meshes.push_back(mesh_instance)
 	
 	if visible:
-		depth_test_meshes.push_back(
-			Global.depth_buffer.add_depth_test_mesh(
-				vertices,
-				uvs,
-				depth_test,
-				depth_range,
-				texture,
-				global_position + Vector2(0.0, -floor_height)
-			)
+		var mesh_weakref = Global.depth_buffer.add_depth_test_mesh(
+			vertices,
+			uvs,
+			depth_test,
+			depth_range,
+			texture,
+			global_position + Vector2(0.0, -floor_height),
+			use_transparency
 		)
+		var mesh = mesh_weakref.get_ref()
+		if mesh:
+			depth_test_meshes.push_back(mesh_weakref)
+			if animation_hframes != 1 or animation_vframes != 1:
+				mesh.material_override.set_shader_param("sprite_animation_hframes", animation_hframes)
+				mesh.material_override.set_shader_param("sprite_animation_vframes", animation_vframes)
+				mesh.material_override.set_shader_param("sprite_animation_frame", animation_frame)
+			mesh.material_override.set_shader_param("dither_limit_min", 0.0 if use_dithering else 1.0)
+			mesh.material_override.set_shader_param("dither_time_coord_multiplier", 1.0 if use_dither_blending else 0.0)
+			mesh.material_override.set_shader_param("sprite_modulate", modulate * self_modulate)
 
 func _queue_generate_collision_box_preview():
 	if not is_queued_generate_collision_box_preview:

--- a/Scripts/Objects/Collision/CollidableBox.gd
+++ b/Scripts/Objects/Collision/CollidableBox.gd
@@ -66,6 +66,9 @@ export var use_dither_blending = true
 # Allow partial transparency, but greatly reduces depth drawing accuracy
 export var use_transparency: bool = false
 
+# Set to true in order to make the box respond to position / height updates
+export var always_update: bool = false setget set_always_update
+
 #------------#
 # Properties #
 #------------#
@@ -172,6 +175,11 @@ func set_animation_frame(new_animation_frame):
 	elif is_ready:
 		_queue_generate_meshes()
 
+func set_always_update(new_always_update):
+	always_update = new_always_update
+	set_physics_process(always_update)
+	set_process(always_update)
+
 #----------------#
 # Node Lifecycle #
 #----------------#
@@ -183,6 +191,8 @@ func _notification(what):
 func _ready():
 	is_ready = true
 	
+	set_always_update(always_update)
+	
 	_initialize_nodes()
 
 func _enter_tree():
@@ -192,6 +202,16 @@ func _enter_tree():
 func _exit_tree():
 	if is_ready:
 		_clear_depth_test_meshes()
+
+func _physics_process(delta):
+	for depth_test_mesh in depth_test_meshes:
+		var mesh = depth_test_mesh.get_ref()
+		if mesh:
+			mesh.global_translation = Vector3(
+				global_position.x,
+				global_position.y - floor_height,
+				0.0
+			)
 
 #---------#
 # Methods #

--- a/Scripts/Objects/Collision/CollidableBoxCollisionBody.gd
+++ b/Scripts/Objects/Collision/CollidableBoxCollisionBody.gd
@@ -1,10 +1,18 @@
 extends StaticBody2D
 
+export var height = 0 setget _set_height
+
 var collision_shapes = []
 var motion_root = null
 
 func _ready():
 	discover_shapes()
+
+func _set_height(new_height):
+	height = new_height
+	for shape in collision_shapes:
+		if shape and "height" in shape:
+			shape.height = height
 
 func discover_shapes():
 	collision_shapes = []
@@ -13,15 +21,23 @@ func discover_shapes():
 			collision_shapes.push_back(child)
 
 func _physics_process(delta):
+	
+	# TODO: Detect player / NPCs by using an Area2D, instead of only colliding for player
+	
 	if not motion_root:
 		# Getting gary. Pretty stupid way to do it. But gary is spawned at runtime...
 		motion_root = PlayerManager.player_motion_root
 	
 	if motion_root:
-		var player_z = motion_root.pos_z
-		
 		for shape in collision_shapes:
-			if shape.height <= player_z:
-				motion_root.add_collision_exception_with(self)
-			else:
-				motion_root.remove_collision_exception_with(self)
+			if not weakref(shape).get_ref():
+				discover_shapes()
+				break
+			call_deferred("_manage_collision_exceptions_between", shape, motion_root)
+			
+
+func _manage_collision_exceptions_between(shape, motion_root):
+	if shape.height <= motion_root.pos_z:
+		motion_root.add_collision_exception_with(self)
+	else:
+		motion_root.remove_collision_exception_with(self)

--- a/Scripts/Objects/Collision/FloorSetter.gd
+++ b/Scripts/Objects/Collision/FloorSetter.gd
@@ -1,23 +1,16 @@
 extends Area2D
 
-export var height : float = 0
+export var height : float = 0 setget _set_height
 
 func _init():
 	connect("body_shape_entered", self, "_on_body_shape_entered")
 	connect("body_shape_exited", self, "_on_body_shape_exited")
 
-func print_tree(node = null, indent = 0):
-	if node == null:
-		node = get_tree().root
-
-	var indentation = ""
-	for i in range(indent):
-		indentation += "  "
-	
-	print(indentation + node.name)
-	
-	for child in node.get_children():
-		print_tree(child, indent + 1)
+func _set_height(new_height):
+	height = new_height
+	for shape in get_children():
+		if shape and "height" in shape:
+			shape.height = height
 
 func _on_body_shape_entered(body_rid, body, body_shape_index, local_shape_index):
 	if body is KinematicBody2D and "floor_layers" in body:

--- a/Scripts/Players/PlayerMotionRoot.gd
+++ b/Scripts/Players/PlayerMotionRoot.gd
@@ -40,13 +40,17 @@ func update_floor():
 		floor_z = max(floor_z, f.height)
 
 func _physics_process(delta):
+	
+	# Floor height could change at any time with movable platforms
+	update_floor()
+	
 	if is_just_teleported:
 		is_just_teleported = false
 		var prev_global_position = global_position
 		move_and_slide(Vector2(0,0))
 		global_position = prev_global_position
 
-	is_on_ground = pos_z <= floor_z
+	is_on_ground = pos_z <= floor_z + 4
 	
 	# Input direction
 	var input_dir = Vector2.ZERO
@@ -78,6 +82,7 @@ func _physics_process(delta):
 		vel.z -= gravity * delta
 	else:
 		vel.z = 0
+		pos_z = floor_z
 	
 	pos_z += vel.z * delta
 	pos_z = max(floor_z, pos_z)

--- a/Scripts/Rendering/DepthBufferObject.gdshader
+++ b/Scripts/Rendering/DepthBufferObject.gdshader
@@ -60,7 +60,7 @@ void fragment() {
 		sprite_texture.a * sprite_modulate.a
 	);
 	
-	float dither_time_coord = TIME * 60.0 * dither_time_coord_multiplier;
+	float dither_time_coord = 0.0; // TIME * 60.0 * dither_time_coord_multiplier;
 	float dither_limit = max(dither_limit_min, get_dither_value(int(FRAGCOORD.x + dither_time_coord) % 4, int(FRAGCOORD.y + dither_time_coord * 6.0) % 4));
 	if (color.a < dither_limit || color.a < alpha_clip) {
 		discard;

--- a/Scripts/Rendering/DepthTestTileMap.gd
+++ b/Scripts/Rendering/DepthTestTileMap.gd
@@ -46,7 +46,7 @@ func _clear_depth_test_meshes():
 func _generate_meshes():
 	_clear_depth_test_meshes()
 	
-	if not visible:
+	if not visible or not tile_set:
 		return
 	
 	var cell_half_size = cell_size / 2.0
@@ -93,7 +93,7 @@ func _generate_meshes():
 						"position": Vector3(
 							position.x,
 							position.y,
-							-position.y - height
+							-position.y - height - cell_origin.y
 						)
 					})
 			

--- a/Scripts/Rendering/SpriteMesh.gdshader
+++ b/Scripts/Rendering/SpriteMesh.gdshader
@@ -1,0 +1,34 @@
+shader_type canvas_item;
+
+uniform float sprite_animation_hframes = 1.0;
+uniform float sprite_animation_vframes = 1.0;
+uniform float sprite_animation_frame = 0.0;
+uniform float sprite_flip_h = 1.0;
+uniform vec4 sprite_modulate = vec4(1.0);
+uniform vec4 sprite_texture_region = vec4(0.0, 0.0, 1.0, 1.0);
+
+void fragment() {
+	vec2 uv_region = vec2(
+		UV.x * sprite_texture_region[2] + sprite_texture_region[0],
+		UV.y * sprite_texture_region[3] + sprite_texture_region[1]
+	);
+	
+	float vframe_offset = floor(sprite_animation_frame / sprite_animation_hframes);
+	float hframe_offset = sprite_animation_frame - (vframe_offset * sprite_animation_hframes);
+	float frame_width = 1.0 / sprite_animation_hframes;
+	float frame_height = 1.0 / sprite_animation_vframes;
+	vec2 sprite_uv = vec2(uv_region.x * sprite_flip_h + (abs(sprite_flip_h - 1.0) / 2.0), uv_region.y) *
+		vec2(frame_width, frame_height) +
+		vec2(frame_width * hframe_offset, frame_height * vframe_offset);
+	
+	vec4 sprite_texture = texture(
+		TEXTURE,
+		sprite_uv
+	);
+	vec4 color = vec4(
+		vec3(sprite_texture.rgb * sprite_modulate.rgb),
+		sprite_texture.a * sprite_modulate.a
+	);
+	
+	COLOR = color;
+}

--- a/Test/CollidableBoxDepthUpdate.gd
+++ b/Test/CollidableBoxDepthUpdate.gd
@@ -1,0 +1,7 @@
+extends Node2D
+
+onready var animation_player = $AnimationPlayer
+
+func _ready():
+	animation_player.play("move_boxes")
+

--- a/Test/CollidableBoxDepthUpdate.tscn
+++ b/Test/CollidableBoxDepthUpdate.tscn
@@ -1,0 +1,109 @@
+[gd_scene load_steps=10 format=2]
+
+[ext_resource path="res://Objects/Rendering/DepthTestFloorSprite.tscn" type="PackedScene" id=1]
+[ext_resource path="res://Assets/Cherry Trail/dirt b.png" type="Texture" id=2]
+[ext_resource path="res://Objects/Collision/CollidableBox.tscn" type="PackedScene" id=3]
+[ext_resource path="res://Assets/General/box.png" type="Texture" id=4]
+[ext_resource path="res://Test/CollidableBoxDepthUpdate.gd" type="Script" id=5]
+[ext_resource path="res://Objects/Collision/Navmesh.tscn" type="PackedScene" id=6]
+[ext_resource path="res://Objects/Collision/NavmeshLayer.tscn" type="PackedScene" id=7]
+
+[sub_resource type="Animation" id=1]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/path = NodePath("Box1:floor_height")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 0,
+"values": [ 0.0 ]
+}
+tracks/1/type = "value"
+tracks/1/path = NodePath("Box2:floor_height")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 0,
+"values": [ 32.0 ]
+}
+
+[sub_resource type="Animation" id=2]
+resource_name = "move_boxes"
+length = 6.0
+tracks/0/type = "value"
+tracks/0/path = NodePath("Box1:floor_height")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/keys = {
+"times": PoolRealArray( 0, 1, 4, 5 ),
+"transitions": PoolRealArray( 1, 1, 1, 1 ),
+"update": 0,
+"values": [ 0.0, -24.0, -24.0, 0.0 ]
+}
+tracks/1/type = "value"
+tracks/1/path = NodePath("Box2:floor_height")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/keys = {
+"times": PoolRealArray( 0, 1, 4, 5 ),
+"transitions": PoolRealArray( 1, 1, 1, 1 ),
+"update": 0,
+"values": [ 32.0, 8.0, 8.0, 32.0 ]
+}
+
+[node name="CollidableBoxDepthUpdate" type="Node2D"]
+script = ExtResource( 5 )
+
+[node name="Floor1" parent="." instance=ExtResource( 1 )]
+position = Vector2( 147, 128 )
+texture = ExtResource( 2 )
+
+[node name="Box1" parent="." instance=ExtResource( 3 )]
+position = Vector2( 146, 132 )
+tile_size = Vector2( 62, 32 )
+texture = ExtResource( 4 )
+texture_offset = Vector2( 0, 20 )
+height = 32.0
+always_update = true
+
+[node name="Floor2" parent="." instance=ExtResource( 1 )]
+position = Vector2( 351, 242 )
+texture = ExtResource( 2 )
+height = 32.0
+
+[node name="Box2" parent="." instance=ExtResource( 3 )]
+position = Vector2( 350, 277 )
+tile_size = Vector2( 62, 32 )
+texture = ExtResource( 4 )
+texture_offset = Vector2( 0, 20 )
+height = 32.0
+floor_height = 32.0
+always_update = true
+
+[node name="Navmesh" parent="." instance=ExtResource( 6 )]
+visible = false
+
+[node name="NavmeshLayer" parent="Navmesh" instance=ExtResource( 7 )]
+polygon = PoolVector2Array( 4, 8, 4, 601, 274, 601, 272, 1 )
+
+[node name="NavmeshLayer2" parent="Navmesh" instance=ExtResource( 7 )]
+position = Vector2( -5, -1 )
+polygon = PoolVector2Array( 272, 4, 275, 601, 454, 603, 452, 1 )
+height = 32.0
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+anims/RESET = SubResource( 1 )
+anims/move_boxes = SubResource( 2 )
+next/move_boxes = "move_boxes"


### PR DESCRIPTION
This adds hframes, vframes, frame properties to CollidableBox so spritesheets can be used (in the same way the player sprite currently works).

![image](https://github.com/spikeystar/GGRPG/assets/4075314/6350c830-d3e4-45b1-bcd3-e827684d74e1)

I disabled dither blending (what you called "frying") in the shader, though I left it as a property in many of the scripts.