### PR TITLE
Add touch area and direction detection to collidable box

### DIFF
--- a/Test/CollidableBoxTouch.tscn
+++ b/Test/CollidableBoxTouch.tscn
@@ -1,0 +1,65 @@
+[gd_scene load_steps=8 format=2]
+
+[ext_resource path="res://Assets/Present Box/Present Animations SS.png" type="Texture" id=1]
+[ext_resource path="res://Test/CollidableBoxTouchTreasureBox.gd" type="Script" id=2]
+[ext_resource path="res://Objects/Collision/CollidableBox.tscn" type="PackedScene" id=3]
+[ext_resource path="res://Objects/Collision/Navmesh.tscn" type="PackedScene" id=6]
+[ext_resource path="res://Objects/Collision/NavmeshLayer.tscn" type="PackedScene" id=7]
+
+[sub_resource type="Animation" id=1]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/path = NodePath("CollidableBox:animation_frame")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 0,
+"values": [ 9 ]
+}
+
+[sub_resource type="Animation" id=2]
+resource_name = "open_box"
+length = 0.2
+tracks/0/type = "value"
+tracks/0/path = NodePath("CollidableBox:animation_frame")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/keys = {
+"times": PoolRealArray( 0, 0.1, 0.2 ),
+"transitions": PoolRealArray( 1, 1, 1 ),
+"update": 1,
+"values": [ 9, 10, 11 ]
+}
+
+[node name="CollidableBoxDepthUpdate" type="Node2D"]
+
+[node name="TreasureBox" type="Node2D" parent="."]
+script = ExtResource( 2 )
+
+[node name="CollidableBox" parent="TreasureBox" instance=ExtResource( 3 )]
+position = Vector2( 263, 155 )
+tile_size = Vector2( 62, 32 )
+grid_size = Vector2( 1, 0.6 )
+texture = ExtResource( 1 )
+texture_offset = Vector2( -3, 20 )
+height = 32.0
+animation_hframes = 9
+animation_vframes = 3
+animation_frame = 9
+detect_touches = true
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="TreasureBox"]
+anims/RESET = SubResource( 1 )
+anims/open_box = SubResource( 2 )
+
+[node name="Navmesh" parent="." instance=ExtResource( 6 )]
+visible = false
+
+[node name="NavmeshLayer" parent="Navmesh" instance=ExtResource( 7 )]
+polygon = PoolVector2Array( 4, 8, 4, 601, 644, 598, 640, 6 )

--- a/Test/CollidableBoxTouchTreasureBox.gd
+++ b/Test/CollidableBoxTouchTreasureBox.gd
@@ -1,0 +1,18 @@
+extends Node2D
+
+onready var collidable_box = $CollidableBox
+onready var animation_player = $AnimationPlayer
+
+var is_opened = false
+
+func _ready():
+	collidable_box.connect("touched", self, "_on_box_touched")
+
+func _on_box_touched(touch_direction):
+	var touch_angle = Vector2(1.0, 0.0).angle_to(touch_direction)
+	if touch_angle < (4 * PI / 5) and touch_angle > (-PI / 3):
+		animation_player.play("open_box")
+		collidable_box.height = 48
+		collidable_box.disconnect("touched", self, "_on_box_touched")
+		is_opened = true
+


### PR DESCRIPTION
This adds a signal called "touched" to CollidableBox, which passes the direction the player was facing when they touched the box, so you can choose to only open it from certain directions.

Check out the Test/CollidableBoxTouch.tscn scene for example.

![image](https://github.com/spikeystar/GGRPG/assets/4075314/57a26308-5e61-445b-a885-df15c08a8eee)
