### PR TITLE
Add logic to handle ceiling collisions with player, and detect bumping collidable box from bottom

### DIFF
--- a/Assets/Present Box/PresentBase.tscn
+++ b/Assets/Present Box/PresentBase.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=9 format=2]
 
+[ext_resource path="res://Scripts/Objects/Interactables/Present.gd" type="Script" id=1]
 [ext_resource path="res://Objects/Collision/CollidableBox.tscn" type="PackedScene" id=2]
-[ext_resource path="res://Test/CollidableBoxTouchTreasureBox.gd" type="Script" id=3]
 [ext_resource path="res://Assets/Present Box/Present Animations SS.png" type="Texture" id=4]
 [ext_resource path="res://Assets/General/Shadows/square shadow.png" type="Texture" id=6]
 
@@ -47,7 +47,7 @@ tracks/1/keys = {
 "times": PoolRealArray( 0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ),
 "update": 1,
-"values": [ Vector2( -0.5, 21 ), Vector2( -0.5, 18 ), Vector2( -0.5, 14 ), Vector2( -0.5, 10 ), Vector2( -0.5, 6 ), Vector2( -0.5, 2 ), Vector2( -0.5, 6 ), Vector2( -0.5, 10 ), Vector2( -0.5, 14 ), Vector2( -0.5, 18 ), Vector2( -0.5, 20 ) ]
+"values": [ Vector2( -0.5, 21 ), Vector2( -0.5, 20 ), Vector2( -0.5, 18 ), Vector2( -0.5, 16 ), Vector2( -0.5, 15 ), Vector2( -0.5, 14 ), Vector2( -0.5, 15 ), Vector2( -0.5, 16 ), Vector2( -0.5, 18 ), Vector2( -0.5, 20 ), Vector2( -0.5, 20 ) ]
 }
 tracks/2/type = "value"
 tracks/2/path = NodePath("CollidableBox:use_collision")
@@ -61,120 +61,9 @@ tracks/2/keys = {
 "update": 1,
 "values": [ true, true, false, false, true, true ]
 }
-tracks/3/type = "value"
-tracks/3/path = NodePath("CollidableBox:floor_height")
-tracks/3/interp = 1
-tracks/3/loop_wrap = true
-tracks/3/imported = false
-tracks/3/enabled = true
-tracks/3/keys = {
-"times": PoolRealArray( 0, 0.5, 1 ),
-"transitions": PoolRealArray( 1, 1, 1 ),
-"update": 0,
-"values": [ 12.0, 48.0, 12.0 ]
-}
-
-[sub_resource type="Animation" id=3]
-length = 0.001
-tracks/0/type = "value"
-tracks/0/path = NodePath("Present:position")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/keys = {
-"times": PoolRealArray( 0 ),
-"transitions": PoolRealArray( 1 ),
-"update": 0,
-"values": [ Vector2( 0, 0 ) ]
-}
-tracks/1/type = "value"
-tracks/1/path = NodePath("Present:animation_frame")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/keys = {
-"times": PoolRealArray( 0 ),
-"transitions": PoolRealArray( 1 ),
-"update": 0,
-"values": [ 0 ]
-}
-tracks/2/type = "value"
-tracks/2/path = NodePath("CollidableBox:position")
-tracks/2/interp = 1
-tracks/2/loop_wrap = true
-tracks/2/imported = false
-tracks/2/enabled = true
-tracks/2/keys = {
-"times": PoolRealArray( 0 ),
-"transitions": PoolRealArray( 1 ),
-"update": 0,
-"values": [ Vector2( 0, 0 ) ]
-}
-tracks/3/type = "value"
-tracks/3/path = NodePath("CollidableBox:animation_frame")
-tracks/3/interp = 1
-tracks/3/loop_wrap = true
-tracks/3/imported = false
-tracks/3/enabled = true
-tracks/3/keys = {
-"times": PoolRealArray( 0 ),
-"transitions": PoolRealArray( 1 ),
-"update": 0,
-"values": [ 0 ]
-}
-tracks/4/type = "value"
-tracks/4/path = NodePath("CollidableBox:use_collision")
-tracks/4/interp = 1
-tracks/4/loop_wrap = true
-tracks/4/imported = false
-tracks/4/enabled = true
-tracks/4/keys = {
-"times": PoolRealArray( 0 ),
-"transitions": PoolRealArray( 1 ),
-"update": 0,
-"values": [ true ]
-}
-tracks/5/type = "value"
-tracks/5/path = NodePath("CollidableBox:height")
-tracks/5/interp = 1
-tracks/5/loop_wrap = true
-tracks/5/imported = false
-tracks/5/enabled = true
-tracks/5/keys = {
-"times": PoolRealArray( 0 ),
-"transitions": PoolRealArray( 1 ),
-"update": 0,
-"values": [ 48.0 ]
-}
-tracks/6/type = "value"
-tracks/6/path = NodePath("CollidableBox:floor_height")
-tracks/6/interp = 1
-tracks/6/loop_wrap = true
-tracks/6/imported = false
-tracks/6/enabled = true
-tracks/6/keys = {
-"times": PoolRealArray( 0 ),
-"transitions": PoolRealArray( 1 ),
-"update": 0,
-"values": [ 96.0 ]
-}
-tracks/7/type = "value"
-tracks/7/path = NodePath("CollidableBox:texture_offset")
-tracks/7/interp = 1
-tracks/7/loop_wrap = true
-tracks/7/imported = false
-tracks/7/enabled = true
-tracks/7/keys = {
-"times": PoolRealArray( 0 ),
-"transitions": PoolRealArray( 1 ),
-"update": 0,
-"values": [ Vector2( -0.5, 21 ) ]
-}
 
 [sub_resource type="Animation" id=4]
-resource_name = "open_box"
+resource_name = "Open Box"
 length = 0.8
 tracks/0/type = "value"
 tracks/0/path = NodePath("CollidableBox:animation_frame")
@@ -189,18 +78,93 @@ tracks/0/keys = {
 "values": [ 0, 1, 2, 3, 4, 5, 6, 7, 8 ]
 }
 
+[sub_resource type="Animation" id=3]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/path = NodePath("CollidableBox:position")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 0,
+"values": [ Vector2( 0, 0 ) ]
+}
+tracks/1/type = "value"
+tracks/1/path = NodePath("CollidableBox:animation_frame")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 0,
+"values": [ 0 ]
+}
+tracks/2/type = "value"
+tracks/2/path = NodePath("CollidableBox:use_collision")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 0,
+"values": [ true ]
+}
+tracks/3/type = "value"
+tracks/3/path = NodePath("CollidableBox:height")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 0,
+"values": [ 20.0 ]
+}
+tracks/4/type = "value"
+tracks/4/path = NodePath("CollidableBox:floor_height")
+tracks/4/interp = 1
+tracks/4/loop_wrap = true
+tracks/4/imported = false
+tracks/4/enabled = true
+tracks/4/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 0,
+"values": [ 80.0 ]
+}
+tracks/5/type = "value"
+tracks/5/path = NodePath("CollidableBox:texture_offset")
+tracks/5/interp = 1
+tracks/5/loop_wrap = true
+tracks/5/imported = false
+tracks/5/enabled = true
+tracks/5/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 0,
+"values": [ Vector2( -0.5, 21 ) ]
+}
+
 [node name="PresentBase" type="Node2D"]
 
 [node name="Present" type="Node2D" parent="."]
-script = ExtResource( 3 )
+script = ExtResource( 1 )
 
 [node name="CollidableBox" parent="Present" instance=ExtResource( 2 )]
 tile_size = Vector2( 44, 20 )
 grid_size = Vector2( 0.9, 0.9 )
 texture = ExtResource( 4 )
 texture_offset = Vector2( -0.5, 21 )
-height = 48.0
-floor_height = 96.0
+height = 20.0
+floor_height = 80.0
 animation_hframes = 9
 animation_vframes = 3
 detect_touches = true
@@ -210,11 +174,11 @@ always_update = true
 playback_speed = 0.6
 anims/Done = SubResource( 1 )
 anims/Idle = SubResource( 2 )
+"anims/Open Box" = SubResource( 4 )
 anims/RESET = SubResource( 3 )
-anims/open_box = SubResource( 4 )
 
 [node name="SquareShadow" type="Sprite" parent="Present"]
 self_modulate = Color( 1, 1, 1, 0.27451 )
-position = Vector2( -1, 16 )
+position = Vector2( -1, -0.999999 )
 scale = Vector2( 0.623138, 0.550726 )
 texture = ExtResource( 6 )

--- a/Gary_s House.tscn
+++ b/Gary_s House.tscn
@@ -36,12 +36,12 @@
 [ext_resource path="res://Assets/Cherry Trail/flower hill c.png" type="Texture" id=34]
 [ext_resource path="res://Assets/Gary's House/Exterior/cloud b.png" type="Texture" id=35]
 [ext_resource path="res://Assets/Gary's House/Exterior/cloud a.png" type="Texture" id=36]
-[ext_resource path="res://Test/PresentTest.tscn" type="PackedScene" id=37]
 [ext_resource path="res://Scripts/Item_Get.gd" type="Script" id=38]
 [ext_resource path="res://UI/Battle/Battle Dialogue.png" type="Texture" id=39]
 [ext_resource path="res://Misc/Font/Dialogue.tres" type="DynamicFont" id=40]
 [ext_resource path="res://Scripts/Area_Specific/Garys_House.gd" type="Script" id=41]
 [ext_resource path="res://Scripts/Objects/SceneTransition/Doorway.gd" type="Script" id=42]
+[ext_resource path="res://Assets/Present Box/PresentBase.tscn" type="PackedScene" id=43]
 
 [sub_resource type="Gradient" id=1]
 offsets = PoolRealArray( 0, 0.059633, 0.807339, 0.981651, 1 )
@@ -421,6 +421,9 @@ position = Vector2( 186, 396 )
 texture = ExtResource( 23 )
 texture_scale = Vector2( 1.8, 1.7 )
 
+[node name="PresentBase" parent="YSort" instance=ExtResource( 43 )]
+position = Vector2( -410, 136 )
+
 [node name="BaseGround" type="Sprite" parent="YSort"]
 position = Vector2( -304, 238 )
 scale = Vector2( 1.6, 1.6 )
@@ -570,6 +573,8 @@ position = Vector2( 74, -131 )
 z_index = 4096
 current = true
 script = ExtResource( 30 )
+vertical_speed = 64.0
+player_offset = Vector2( 0, 0 )
 minPos = Vector2( -395, -90 )
 maxPos = Vector2( 65, 190 )
 follow_player = true
@@ -606,8 +611,5 @@ item_name = "Pretty Gem"
 [node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="Item_Get"]
 position = Vector2( 184, -34 )
 polygon = PoolVector2Array( -78, -110, -34, -92, -51, -76, -96, -96 )
-
-[node name="Present" parent="." instance=ExtResource( 37 )]
-position = Vector2( -456, 11 )
 
 [connection signal="item_get" from="Item_Get" to="Camera2D" method="_on_Item_Get_item_get"]

--- a/NPC/NPC_ShadowAreaCheck.gd
+++ b/NPC/NPC_ShadowAreaCheck.gd
@@ -1,6 +1,7 @@
 extends Area2D
 
-const LOWEST_Z : int = -256;
+const LOWEST_Z : int = 0
+const HIGHEST_Z : int = 512
 
 onready var motion_root = get_parent();
 
@@ -16,7 +17,16 @@ onready var motion_root = get_parent();
 
 func _process(delta):
 	var floor_z = LOWEST_Z
+	var ceiling_z = HIGHEST_Z
 	for area in get_overlapping_areas():
-		if area.has_method("floor_check"):
-			floor_z = max(floor_z, area.height)
+		var check_floor_z = 0
+		var check_ceiling_z = -128
+		if "height" in area:
+			check_floor_z = area.height
+		if "bottom" in area:
+			check_ceiling_z = area.bottom
+		if check_floor_z <= motion_root.pos_z:
+			floor_z = max(floor_z, check_floor_z)
+		else:
+			ceiling_z = min(ceiling_z, check_ceiling_z)
 	motion_root.shadow_z = floor_z

--- a/Scripts/Objects/Collision/CollidableBoxCollisionBody.gd
+++ b/Scripts/Objects/Collision/CollidableBoxCollisionBody.gd
@@ -1,6 +1,7 @@
 extends StaticBody2D
 
 export var height = 0 setget _set_height
+export var bottom = -128 setget _set_bottom
 
 var collision_shapes = []
 var motion_root = null
@@ -13,6 +14,12 @@ func _set_height(new_height):
 	for shape in collision_shapes:
 		if shape and "height" in shape:
 			shape.height = height
+
+func _set_bottom(new_bottom):
+	bottom = new_bottom
+	for shape in collision_shapes:
+		if shape and "bottom" in shape:
+			shape.bottom = bottom
 
 func discover_shapes():
 	collision_shapes = []
@@ -37,7 +44,7 @@ func _physics_process(delta):
 			
 
 func _manage_collision_exceptions_between(shape, motion_root):
-	if shape.height <= motion_root.pos_z:
+	if motion_root.pos_z >= shape.height or motion_root.pos_z + motion_root.player_height < shape.bottom:
 		motion_root.add_collision_exception_with(self)
 	else:
 		motion_root.remove_collision_exception_with(self)

--- a/Scripts/Objects/Collision/FloorLayer.gd
+++ b/Scripts/Objects/Collision/FloorLayer.gd
@@ -1,6 +1,7 @@
 extends Node
 
 export var height : float = 0
+export var bottom : float = -128
 
 var isSolid : bool = true;
 

--- a/Scripts/Objects/Collision/FloorSetter.gd
+++ b/Scripts/Objects/Collision/FloorSetter.gd
@@ -1,6 +1,10 @@
 extends Area2D
 
+# This is the height at which the floor is represented
 export var height : float = 0 setget _set_height
+
+# This is the z-position below the floor where the player can start walking underneath it
+export var bottom : float = -128 setget _set_bottom
 
 func _init():
 	connect("body_shape_entered", self, "_on_body_shape_entered")
@@ -11,6 +15,12 @@ func _set_height(new_height):
 	for shape in get_children():
 		if shape and "height" in shape:
 			shape.height = height
+
+func _set_bottom(new_bottom):
+	bottom = new_bottom
+	for shape in get_children():
+		if shape and "bottom" in shape:
+			shape.bottom = bottom
 
 func _on_body_shape_entered(body_rid, body, body_shape_index, local_shape_index):
 	if body is KinematicBody2D and "floor_layers" in body:

--- a/Scripts/Objects/Interactables/Present.gd
+++ b/Scripts/Objects/Interactables/Present.gd
@@ -1,0 +1,17 @@
+extends Node2D
+
+onready var collidable_box = $CollidableBox
+onready var animation_player = $AnimationPlayer
+
+var is_opened = false
+
+func _ready():
+	animation_player.play("Idle")
+	collidable_box.connect("bumped_from_bottom", self, "_on_bumped_from_bottom")
+
+func _on_bumped_from_bottom():
+	yield(get_tree().create_timer(0.1), "timeout")
+	animation_player.play("Open Box")
+	animation_player.playback_speed = 1.0
+	collidable_box.disconnect("bumped_from_bottom", self, "_on_bumped_from_bottom")
+	is_opened = true

--- a/Scripts/Objects/Interactables/TreasureChest.gd
+++ b/Scripts/Objects/Interactables/TreasureChest.gd
@@ -3,6 +3,14 @@ extends Node2D
 onready var collidable_box = $CollidableBox
 onready var animation_player = $AnimationPlayer
 
+enum OpenPositions {
+	LEFT = 0,
+	RIGHT = 1
+}
+
+# Whether the box opens from bottom left or bottom right
+export(OpenPositions) var open_position = OpenPositions.LEFT
+
 var is_opened = false
 
 func _ready():
@@ -11,10 +19,18 @@ func _ready():
 func _on_box_touched(touch_direction):
 	yield(get_tree().create_timer(0.1), "timeout")
 	var touch_angle = Vector2(1.0, 0.0).angle_to(touch_direction)
-	if touch_angle < (4 * PI / 5) and touch_angle > (-PI / 3):
+	if (
+		(
+			open_position == OpenPositions.LEFT and
+			touch_angle < (4 * PI / 5) and
+			touch_angle > (-PI / 3)
+		) or (
+			open_position == OpenPositions.RIGHT and
+			(touch_angle > (PI / 6) or touch_angle < -(2 * PI / 3))
+		)
+	):
 		animation_player.play("open_box")
 		animation_player.playback_speed = 0.5
 		collidable_box.height = 48
 		collidable_box.disconnect("touched", self, "_on_box_touched")
 		is_opened = true
-

--- a/Scripts/Objects/SceneTransition/Doorway.gd
+++ b/Scripts/Objects/SceneTransition/Doorway.gd
@@ -29,7 +29,8 @@ func _ready():
 	position.y += height
 
 func _on_start_checking_body_entered():
-	connect("body_entered", self, "_on_body_entered")
+	if not is_connected("body_entered", self, "_on_body_entered"):
+		connect("body_entered", self, "_on_body_entered")
 
 func _input(event):
 	if event.is_action_pressed("ui_select") and get_overlapping_bodies().size() > 0 and gary_entered:

--- a/Scripts/Players/PlayerMotionRoot.gd
+++ b/Scripts/Players/PlayerMotionRoot.gd
@@ -1,6 +1,7 @@
 extends KinematicBody2D
 
-const LOWEST_Z: int = 0;
+const LOWEST_Z : int = 0;
+const HIGHEST_Z : int = 512;
 
 export var spawn_z = 0
 export var player_acceleration = 12
@@ -9,11 +10,13 @@ export var max_player_speed = 2
 export var gravity = 9.8
 export var max_vertical_speed = 20
 export var jump_velocity = 10
+export var player_height = 64
 
 var is_player_motion_root = true
 
 #Movement
 var floor_z : float = LOWEST_Z
+var ceiling_z : float = HIGHEST_Z
 var shadow_z : float = 0
 var pos_z : float
 var teleport_z : float
@@ -50,8 +53,12 @@ func set_facing_direction(direction : Vector2):
 
 func update_floor():
 	floor_z = LOWEST_Z
+	ceiling_z = HIGHEST_Z
 	for f in floor_layers:
-		floor_z = max(floor_z, f.height)
+		if f.bottom <= pos_z:
+			floor_z = max(floor_z, f.height)
+		else:
+			ceiling_z = min(ceiling_z, f.bottom)
 
 func _physics_process(delta):
 	#var freeze = PlayerManager.freeze
@@ -111,7 +118,13 @@ func _physics_process(delta):
 		
 	
 	pos_z += vel.z * delta
+	
+	var current_max_z = ceiling_z - player_height - 1
+	pos_z = min(current_max_z, pos_z)
 	pos_z = max(floor_z, pos_z)
+	
+	if pos_z == current_max_z and vel.z > 0:
+		vel.z = 0
 	
 	var delta2D = Vector2(vel.x, -vel.y * 0.5)
 	move_and_slide(delta2D)

--- a/Scripts/ShadowLayerCheck.gd
+++ b/Scripts/ShadowLayerCheck.gd
@@ -1,5 +1,7 @@
 extends Area2D
-const LOWEST_Z : int = -256;
+
+const LOWEST_Z : int = 0
+const HIGHEST_Z : int = 512
 
 onready var motion_root = get_parent();
 
@@ -12,12 +14,20 @@ onready var motion_root = get_parent();
 #	motion_root.shadow_z = floor_z
 #	print(floor_z)
 
-
 func _process(delta):
 	var floor_z = LOWEST_Z
+	var ceiling_z = HIGHEST_Z
 	for area in get_overlapping_areas():
-		if area.has_method("floor_check"):
-			floor_z = max(floor_z, area.height)
+		var check_floor_z = 0
+		var check_ceiling_z = -128
+		if "height" in area:
+			check_floor_z = area.height
+		if "bottom" in area:
+			check_ceiling_z = area.bottom
+		if check_floor_z <= motion_root.pos_z:
+			floor_z = max(floor_z, check_floor_z)
+		else:
+			ceiling_z = min(ceiling_z, check_ceiling_z)
 	motion_root.shadow_z = floor_z
 
 #func _on_area_shape_entered(_area_rid : RID, area : Area2D, area_shape_index : int, _local_shape_index : int):

--- a/Test/CollidableBoxTouch.tscn
+++ b/Test/CollidableBoxTouch.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=8 format=2]
+[gd_scene load_steps=11 format=2]
 
 [ext_resource path="res://Assets/Present Box/Present Animations SS.png" type="Texture" id=1]
-[ext_resource path="res://Test/CollidableBoxTouchTreasureBox.gd" type="Script" id=2]
+[ext_resource path="res://Scripts/Objects/Interactables/TreasureChest.gd" type="Script" id=2]
 [ext_resource path="res://Objects/Collision/CollidableBox.tscn" type="PackedScene" id=3]
+[ext_resource path="res://Assets/Present Box/PresentBase.tscn" type="PackedScene" id=4]
 [ext_resource path="res://Objects/Collision/Navmesh.tscn" type="PackedScene" id=6]
 [ext_resource path="res://Objects/Collision/NavmeshLayer.tscn" type="PackedScene" id=7]
 
@@ -37,12 +38,43 @@ tracks/0/keys = {
 "values": [ 9, 10, 11 ]
 }
 
+[sub_resource type="Animation" id=3]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/path = NodePath("CollidableBox:animation_frame")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 0,
+"values": [ 9 ]
+}
+
+[sub_resource type="Animation" id=4]
+resource_name = "open_box"
+length = 0.2
+tracks/0/type = "value"
+tracks/0/path = NodePath("CollidableBox:animation_frame")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/keys = {
+"times": PoolRealArray( 0, 0.1, 0.2 ),
+"transitions": PoolRealArray( 1, 1, 1 ),
+"update": 1,
+"values": [ 9, 10, 11 ]
+}
+
 [node name="CollidableBoxDepthUpdate" type="Node2D"]
 
-[node name="TreasureBox" type="Node2D" parent="."]
+[node name="TreasureBoxLeft" type="Node2D" parent="."]
 script = ExtResource( 2 )
 
-[node name="CollidableBox" parent="TreasureBox" instance=ExtResource( 3 )]
+[node name="CollidableBox" parent="TreasureBoxLeft" instance=ExtResource( 3 )]
 position = Vector2( 263, 155 )
 tile_size = Vector2( 62, 32 )
 grid_size = Vector2( 1, 0.6 )
@@ -54,9 +86,34 @@ animation_vframes = 3
 animation_frame = 9
 detect_touches = true
 
-[node name="AnimationPlayer" type="AnimationPlayer" parent="TreasureBox"]
+[node name="AnimationPlayer" type="AnimationPlayer" parent="TreasureBoxLeft"]
 anims/RESET = SubResource( 1 )
 anims/open_box = SubResource( 2 )
+
+[node name="TreasureBoxRight" type="Node2D" parent="."]
+position = Vector2( 70, 1 )
+script = ExtResource( 2 )
+open_position = 1
+
+[node name="CollidableBox" parent="TreasureBoxRight" instance=ExtResource( 3 )]
+position = Vector2( 263, 155 )
+tile_size = Vector2( 62, 32 )
+grid_size = Vector2( 0.6, 1 )
+texture = ExtResource( 1 )
+texture_scale = Vector2( -1, 1 )
+texture_offset = Vector2( 3, 20 )
+height = 32.0
+animation_hframes = 9
+animation_vframes = 3
+animation_frame = 9
+detect_touches = true
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="TreasureBoxRight"]
+anims/RESET = SubResource( 3 )
+anims/open_box = SubResource( 4 )
+
+[node name="PresentBase" parent="." instance=ExtResource( 4 )]
+position = Vector2( 97, 167 )
 
 [node name="Navmesh" parent="." instance=ExtResource( 6 )]
 visible = false


### PR DESCRIPTION
This adds a "bottom" property to floor shapes / areas where if the player is below the "bottom" of the floor, it is treated like a ceiling. So the player can jump up and hit the ceiling, and fall back down.

Going along with this, added "bumped_from_bottom" signal to CollidableBox script to detect when the player hits the block with their head like a mario block.